### PR TITLE
Some minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,11 @@
 obj/
 obj.*/
 
-.vscode/
 ee/loader/irx/
 iop/patches/
 iop/fileio/
 releases/
+
+.*
+!.clang-format
+!.github


### PR DESCRIPTION
ps2homebrew Docker image automatically updated when ps2sdk docker image is generated. Delay 2-3 minutes. It is faster, cause github.com docker repository is faster then docker.com. Also it is faster cause no need to install additional tools.
Fixed gitignore to not include .DB_Store and other weird files from macos.
Fixed some grammar errors in readme.