### PR TITLE
Revert some of the changes used for fio/fileXio logic

### DIFF
--- a/ee/Rules.make
+++ b/ee/Rules.make
@@ -17,7 +17,7 @@ EE_SAMPLE_DIR ?= samples/
 EE_NEWLIB_NANO ?= 0
 EE_COMPACT_EXECUTABLE ?= 0
 
-EE_NANO_NEWLIB_LIBS ?= -lcdvd -lcglue -lpthreadglue -lkernel
+EE_NANO_NEWLIB_LIBS ?= -lcglue -lpthreadglue -lkernel
 
 ifneq (x$(EE_NEWLIB_NANO), x0)
 EE_ADDITIONAL_DEPS := $(EE_ADDITIONAL_DEPS)

--- a/ee/loader/src/main.c
+++ b/ee/loader/src/main.c
@@ -14,7 +14,6 @@ _off64_t lseek64 (int __filedes, _off64_t __offset, int __whence); // should be 
 #include <loadfile.h>
 #include <iopcontrol.h>
 #include <libcdvd-common.h>
-#include <file-advanced.h>
 
 // Other
 #include "elf.h"
@@ -38,8 +37,7 @@ DISABLE_PATCHED_FUNCTIONS();      // Disable the patched functionalities
 DISABLE_EXTRA_TIMERS_FUNCTIONS(); // Disable the extra functionalities for timers
 PS2_DISABLE_AUTOSTART_PTHREAD();  // Disable pthread functionality
 void _libcglue_timezone_update() {}; // Disable timezone update
-
-FILE_SWAP_PS2SDK_FUNCTIONS(); // Swap PS2SDK functions from fileIO to fileXio once the IOP modules are loaded
+void _libcglue_rtc_update() {}; // Disable rtc update
 
 #define OPL_MOD_STORAGE 0x00097000 //(default) Address of the module storage region
 /*
@@ -1052,7 +1050,7 @@ int main(int argc, char *argv[])
      */
     printf("Reboot IOP into Load Environment (LE)\n");
 #if 1
-    //swapToFileIO();
+    //fileXioExit();
     SifExitIopHeap();
     SifLoadFileExit();
     SifExitRpc();
@@ -1073,7 +1071,7 @@ int main(int argc, char *argv[])
     if (modlist_start(&drv.mod_all_env) < 0)
         return -1;
     if (modlist_get_by_name(&drv.mod_l_env, "fileXio.irx") != NULL)
-        swapToFileXio();
+        fileXioInit();
 
     // FAKEMOD optional module
     // Only loaded when modules need to be faked


### PR DESCRIPTION
## Description
This PR basically reverts some of the changes that I did previously to support the new logic that PS2SDK had for dealing with `fio/fileXio` logic.

Additionally, I have also disabled `_libcglue_rtc_update` and `libcdvd` because it not used.

This PR requires to be merged first: https://github.com/ps2dev/ps2sdk/pull/491

Cheers.