### PR TITLE
[hdlfs]: dont stay resident on ram if device failed to register

### DIFF
--- a/iop/hdlfs/src/hdlfs.c
+++ b/iop/hdlfs/src/hdlfs.c
@@ -401,7 +401,6 @@ int _start(int argc, char *argv[])
 {
     M_DEBUG("HDLoader read-only filesystem driver\n");
 
-    AddDrv(&hdl_device);
-
+    if(AddDrv(&hdl_device) != 0) { return MODULE_NO_RESIDENT_END; }
     return MODULE_RESIDENT_END;
 }


### PR DESCRIPTION
if addDrv failed, return no resident end to avoid wasting RAM and to allow faster issue detection and error handling