### PR TITLE
ee_core: improve linkfile

### DIFF
--- a/ee/ee_core/linkfile
+++ b/ee/ee_core/linkfile
@@ -1,29 +1,29 @@
-/*
-	Copyright 2009-2010, Ifcaro, jimmikaelkael & Polo
-	Copyright 2006-2008 Polo
-	Licenced under Academic Free License version 3.0
-	Review OPNPS2LD README & LICENSE files for further details.
-
-	Copyright 2001-2004, ps2dev - http://www.ps2dev.org
-	Licenced under Academic Free License version 2.0
-	Review ps2sdk README & LICENSE files for further details.
-
-	Standard linkfile
-*/
-
 ENTRY(_start);
 
 MEMORY {
-	ram84	: ORIGIN = 0x00084000, LENGTH = 77312 /* 0x00084000 - 0x00096E00: free */
-	stack	: ORIGIN = 0x00096E00, LENGTH = 512   /* 0x00096E00 - 0x00097000: free */
-	modules	: ORIGIN = 0x00097000, LENGTH = 228K  /* 0x00097000 - 0x000D0000: free */
-	ramD0	: ORIGIN = 0x000D0000, LENGTH = 192K  /* 0x000D0000 - 0x00100000: usually free, but some games use it. */
+	/* Main layout of PS2 EE memory */
+	bios_rom   : ORIGIN = 0x00000000, LENGTH = 512K  /* The ROM overlaps with 512K of RAM. This RAM is used by the BIOS. */
+	bios_ram   : ORIGIN = 0x00080000, LENGTH = 512K  /* Used for BIOS updates, but mostly not used */
+	game_ram   : ORIGIN = 0x00100000, LENGTH =  31M
+	scratchpad : ORIGIN = 0x70000000, LENGTH =  16K
+
+	/* BIOS RAM memory layout */
+	bios_ram80 : ORIGIN = 0x00080000, LENGTH =   8K  /* Used: old idle thread and alarm dispatcher */
+	bios_ram82 : ORIGIN = 0x00082000, LENGTH =   8K  /* Used: new idle thread and alarm dispatcher or EELOAD */
+	bios_ram84 : ORIGIN = 0x00084000, LENGTH = 304K  /* Free - is this always true? */
+	bios_ramD0 : ORIGIN = 0x000D0000, LENGTH = 192K  /* Free for most games - what games? */
+
+	/* EE_CORE memory layout, currently only using bios_ram84 area */
+	ee_core    : ORIGIN = 0x00084000, LENGTH =  72K
+	stack      : ORIGIN = 0x00096000, LENGTH =   4K
+	modules    : ORIGIN = 0x00097000, LENGTH = 228K
 }
+
+REGION_ALIAS("MAIN_REGION", ee_core);
 
 PHDRS {
   text PT_LOAD;
 }
-
 
 SECTIONS {
 	.text : {
@@ -34,12 +34,12 @@ SECTIONS {
 		KEEP(*(.init))
 		KEEP(*(.fini))
 		QUAD(0)
-	} >ram84 :text
+	} >MAIN_REGION :text
 
 	PROVIDE(_etext = .);
 	PROVIDE(etext = .);
 
-	.reginfo : { *(.reginfo) } >ram84
+	.reginfo : { *(.reginfo) } >MAIN_REGION
 
 	/* Global/static constructors and deconstructors. */
 	.ctors ALIGN(16): {
@@ -47,20 +47,20 @@ SECTIONS {
 		KEEP(*(EXCLUDE_FILE(*crtend*.o) .ctors))
 		KEEP(*(SORT(.ctors.*)))
 		KEEP(*(.ctors))
-	} >ram84
+	} >MAIN_REGION
 	.dtors ALIGN(16): {
 		KEEP(*crtbegin*.o(.dtors))
 		KEEP(*(EXCLUDE_FILE(*crtend*.o) .dtors))
 		KEEP(*(SORT(.dtors.*)))
 		KEEP(*(.dtors))
-	} >ram84
+	} >MAIN_REGION
 
 	/* Static data.  */
 	.rodata ALIGN(128): {
 		*(.rodata)
 		*(.rodata.*)
 		*(.gnu.linkonce.r*)
-	} >ram84
+	} >MAIN_REGION
 
 	.data ALIGN(128): {
 		_fdata = . ;
@@ -68,20 +68,20 @@ SECTIONS {
 		*(.data.*)
 		*(.gnu.linkonce.d*)
 		SORT(CONSTRUCTORS)
-	} >ram84
+	} >MAIN_REGION
 
-	.rdata ALIGN(128): { *(.rdata) } >ram84
-	.gcc_except_table ALIGN(128): { *(.gcc_except_table) } >ram84
+	.rdata ALIGN(128): { *(.rdata) } >MAIN_REGION
+	.gcc_except_table ALIGN(128): { *(.gcc_except_table) } >MAIN_REGION
 
 	_gp = ALIGN(128) + 0x7ff0;
-	.lit4 ALIGN(128): { *(.lit4) } >ram84
-	.lit8 ALIGN(128): { *(.lit8) } >ram84
+	.lit4 ALIGN(128): { *(.lit4) } >MAIN_REGION
+	.lit8 ALIGN(128): { *(.lit8) } >MAIN_REGION
 
 	.sdata ALIGN(128): {
 		*(.sdata)
 		*(.sdata.*)
 		*(.gnu.linkonce.s*)
-	} >ram84
+	} >MAIN_REGION
 
 	_edata = .;
 	PROVIDE(edata = .);
@@ -93,21 +93,22 @@ SECTIONS {
 		*(.sbss.*)
 		*(.gnu.linkonce.sb*)
 		*(.scommon)
-	} >ram84
+	} >MAIN_REGION
 
 	.bss ALIGN(128) : {
 		*(.bss)
 		*(.bss.*)
 		*(.gnu.linkonce.b*)
 		*(COMMON)
-	} >ram84
+	} >MAIN_REGION
 	_end_bss = .;
 
-	/* Symbols needed by crt0.s.  */
-	PROVIDE(_heap_size = -1);
-	PROVIDE(_stack = .);
-	PROVIDE(_stack_size = 0x00097000 - _stack);	/* Any remaining space up to the module storage region, is available for the stack. */
+	_end = .;
+	end = _end;
 
-	_end = _stack + _stack_size ;
-	PROVIDE(end = _end);
+	_heap_size = -1; /* automatically from _end to _stack */
+
+	_stack = ORIGIN(stack);
+	_stack_size = LENGTH(stack);
+	_stack_end = _stack + _stack_size;
 }

--- a/ee/ee_core/src/asm.S
+++ b/ee/ee_core/src/asm.S
@@ -27,7 +27,7 @@
 
 .text
 
-.extern _end
+.extern _stack_end
 
 /* libkernel */
 .extern memset
@@ -69,7 +69,7 @@ _SifSetDma:
     daddu   $a2, $sp, $zero
 
     /* change the stack pointer */
-    la      $sp, _end
+    la      $sp, _stack_end
 
     /* call New_SifSetDma, preserving ra and a2 registers values */
     addiu   $sp, $sp, -0x10
@@ -140,7 +140,7 @@ _Apply_Mode3:
     daddu   $a0, $sp, $zero
 
     /* change the stack pointer */
-    la      $sp, _end
+    la      $sp, _stack_end
 
     /* preserving ra and a0 registers values */
     addiu   $sp, $sp, -0x10
@@ -282,7 +282,7 @@ InitRegsExecPS2:
     por     $t8, $zero, $zero
     por     $t9, $zero, $zero
     por     $gp, $zero, $zero
-    la      $sp, _end               # Reset SP to top of stack
+    la      $sp, _stack_end         # Reset SP to top of stack
     por     $fp, $zero, $zero
     # por     $ra, $zero, $zero       # Required for returning
     mthi    $zero

--- a/ee/ee_core/src/syshook.c
+++ b/ee/ee_core/src/syshook.c
@@ -26,7 +26,7 @@ int iop_reboot_count = 0;
 
 extern void *ModStorageStart, *ModStorageEnd;
 extern void *eeloadCopy, *initUserMemory;
-extern void *_end;
+extern void *_stack_end;
 
 // Global data
 u32 (*Old_SifSetDma)(SifDmaTransfer_t *sdd, s32 len);
@@ -80,7 +80,7 @@ void sysLoadElf(char *filename, int argc, char **argv)
     DPRINTF("t_loadElf: cleaning user memory...");
 
     // wipe user memory
-    WipeUserMemory((void *)&_end, (void *)ModStorageStart);
+    WipeUserMemory((void *)&_stack_end, (void *)ModStorageStart);
     // The upper half (from ModStorageEnd to GetMemorySize()) is taken care of by LoadExecPS2().
     // WipeUserMemory((void *)ModStorageEnd, (void *)GetMemorySize());
 


### PR DESCRIPTION
This should fix the "Wrong `_end` on linkfile for `ee_core` binary" issue.

I've also tried to better define all memory sections.
More information on the `bios_ram` memory usage is highly welcome.

fixes #23 