### PR TITLE
Always parse ELF path for game ID

### DIFF
--- a/ee/loader/src/main.c
+++ b/ee/loader/src/main.c
@@ -1618,15 +1618,16 @@ gsm_done:
         }
         fname_end[1] = '1';
         fname_end[2] = '\0';
-
-        // Locate and set GameID
+    }
+    
+    /*
+     * Check if ELF file path contains Game ID
+     */
+    if ((strlen(sys.sELFFile) > 18) && (sys.sELFFile[12] == '_') && (sys.sELFFile[16] == '.')) {
         memcpy(sGameID, &sys.sELFFile[8], 11);
         sGameID[11] = '\0';
-    }
-    else {
-        // Manually specifying an ELF file == no GameID
+    } else 
         sGameID[0] = '\0';
-    }
 
     /*
      * Get ELF/game compatibility flags


### PR DESCRIPTION
Currently, passing `-elf` argument to Neutrino disables game-specific compatibility fixes because the game ID is not parsed.
This PR makes it so the ELF path is always parsed for game ID with some simple sanity checks, namely:
- Making sure the string in `sELFFile` is long enough to store `cdrom0:\????_???.??`
- Making sure the path contains both `_` and `.` at known locations.

This allows us to skip parsing ISO for the executable path and the game ID, enabling frontends to simply pass the path to executable and potentially making quickboot even quicker, especially for larger ISO files that have the SYSTEM.CNF at the end of the disc.