### PR TITLE
fix root_dir check

### DIFF
--- a/pc/udpfs_server.py
+++ b/pc/udpfs_server.py
@@ -352,7 +352,7 @@ class UdpfsServer:
         resolved = os.path.realpath(os.path.join(self.root_dir, client_path))
 
         # Ensure within root
-        if not resolved.startswith(self.root_dir + os.sep) and resolved != self.root_dir:
+        if not resolved.startswith((self.root_dir + os.sep).replace('\\\\', '\\')) and resolved != self.root_dir:
             return None
 
         return resolved


### PR DESCRIPTION
This fixes the error resulting in `EACCES (path traversal or no root_dir)`

self.root_dir already contains `D:\` so adding os.sep results in `D:\\` which fails then returns None resulting in the EACCES error.  
The simpler fix would be to remove ` + os.sep` but I am unsure if that could break something else.