### PR TITLE
UDPFS server: fix CISO decompression

### DIFF
--- a/pc/compressed_iso/cso.py
+++ b/pc/compressed_iso/cso.py
@@ -18,7 +18,7 @@ class CsoFileWrapper(CompressedFileWrapper):
     
     CSO Header (24 bytes):
         - magic: 4 bytes (0x4F534943 = "CISO")
-        - header_size: 4 bytes (little-endian)
+        - header_size: 4 bytes (little-endian, might be filled with zeroes)
         - uncompressed_size: 8 bytes (little-endian)
         - block_size: 4 bytes (little-endian)
         - version: 1 byte
@@ -59,7 +59,6 @@ class CsoFileWrapper(CompressedFileWrapper):
         if magic != CSO_MAGIC:
             raise ValueError(f"Invalid CSO magic: 0x{magic:08X}, expected 0x{CSO_MAGIC:08X}")
         
-        header_size = struct.unpack('<I', header[4:8])[0]
         self.uncompressed_size = struct.unpack('<Q', header[8:16])[0]
         self.block_size = struct.unpack('<I', header[16:20])[0]
         # version = header[20]
@@ -73,7 +72,7 @@ class CsoFileWrapper(CompressedFileWrapper):
         self._num_blocks = (self.uncompressed_size + self.block_size - 1) // self.block_size
         
         # Read block offset table (CSO has num_blocks + 1 entries)
-        self.file.seek(header_size)
+        self.file.seek(24)
         offset_data = self.file.read((self._num_blocks + 1) * 4)
         
         if len(offset_data) < (self._num_blocks + 1) * 4:
@@ -105,14 +104,17 @@ class CsoFileWrapper(CompressedFileWrapper):
         # Check if block is uncompressed (MSB set)
         is_uncompressed = (raw_offset & 0x80000000) != 0
         
-        # Calculate actual offset (remove MSB, apply alignment)
+        # Calculate actual offset (remove MSB, apply alignment if compressed)
         offset = (raw_offset & 0x7FFFFFFF) << self.align
-        next_offset = (next_raw_offset & 0x7FFFFFFF) << self.align
-        compressed_size = next_offset - offset
-        
+        if is_uncompressed:
+            read_size = self.block_size
+        else:
+            next_offset = (next_raw_offset & 0x7FFFFFFF) << self.align
+            read_size = next_offset - offset
+
         # Read compressed data
         self.file.seek(offset)
-        compressed_data = self.file.read(compressed_size)
+        compressed_data = self.file.read(read_size)
         
         if is_uncompressed:
             decompressed = compressed_data


### PR DESCRIPTION
While reimplementing the UDPFS server in Go, I've encountered an issue with CISO images.

Despite the original CISO implementation specifying the 4 bytes after the CISO magic are the header size, the images produced by the original CISO utility by BOOSTER and [mCISO](https://github.com/sindastra/psp-mciso) _do not_ set this field.
Any images compressed by these utilities will not work because the first block will always point to the header, not the actual block 0 of the block map.

I've also noticed an issue with how uncompressed blocks are handled.
The original source uses block size from CISO header instead of calculating the location using the next block offset:
```c
read_pos = index << (ciso.align);
if(plain)
{
	read_size = ciso.block_size;
}
else
{
	index2 = index_buf[block+1] & 0x7fffffff;
	read_size = (index2-index) << (ciso.align);
}
```
While this likely won't affect anything as it will always point to the next block anyway, I felt it was a good idea to replicate the original behavior.